### PR TITLE
Fix a grammatical error in status change message.

### DIFF
--- a/zerver/webhooks/github_webhook/tests.py
+++ b/zerver/webhooks/github_webhook/tests.py
@@ -203,7 +203,7 @@ class GithubWebhookTest(WebhookTestCase):
 
     def test_status_msg(self):
         # type: () -> None
-        expected_message = u"[9049f12](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed it's status to success"
+        expected_message = u"[9049f12](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to success"
         self.send_and_test_stream_message('status', self.EXPECTED_SUBJECT_REPO_EVENTS, expected_message, HTTP_X_GITHUB_EVENT='status')
 
     def test_pull_request_review_msg(self):

--- a/zerver/webhooks/github_webhook/view.py
+++ b/zerver/webhooks/github_webhook/view.py
@@ -270,7 +270,7 @@ def get_status_body(payload):
         )
     else:
         status = payload['state']
-    return u"[{}]({}) changed it's status to {}".format(
+    return u"[{}]({}) changed its status to {}".format(
         payload['sha'][:7],  # TODO
         payload['commit']['html_url'],
         status


### PR DESCRIPTION
The whole story:

> Github: cc0d391 changed it's status to pending
> Github: cc0d391 changed it's status to pending
> Github: cc0d391 changed it's status to error
> 
> KW: Did we write this message ourselves?!? The grammar error is driving me crazy. :-)
> SF: No, it's either Github's fault or Zulip's!
> \+ Sigh. I assume it's part of the Travis-CI integration?
> – I checked, and that message is not in the JSON message that comes from Github
> – Look what I found! https://github.com/zulip/zulip/blob/7227f488c8f9d77fb30b9276192f1147e30c981b/zerver/webhooks/github_webhook/view.py#L273
> \+ Time for a pull request!
> – My moment has arrived.